### PR TITLE
added timeout handlers for Dota client init requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.avenga</groupId>
     <artifactId>parent-steam-client</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/steam-client/pom.xml
+++ b/steam-client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.avenga</groupId>
         <artifactId>parent-steam-client</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>steam-client</artifactId>

--- a/steam-client/src/main/java/com/avenga/steamclient/steam/dota/AbstractDotaClient.java
+++ b/steam-client/src/main/java/com/avenga/steamclient/steam/dota/AbstractDotaClient.java
@@ -21,12 +21,16 @@ public abstract class AbstractDotaClient {
 
     protected final AbstractGameCoordinator gameCoordinator;
 
-    protected long callbackWaitTimeout = 20000;
+    /**
+     * Time which init callback handlers will wait for packet message from Steam Network server
+     */
+    protected long callbackWaitTimeout;
     protected int applicationId;
 
-    public AbstractDotaClient(AbstractGameCoordinator gameCoordinator, int applicationId) throws CallbackTimeoutException {
+    public AbstractDotaClient(AbstractGameCoordinator gameCoordinator, int applicationId, long callbackWaitTimeout) throws CallbackTimeoutException {
         this.gameCoordinator = gameCoordinator;
         this.applicationId = applicationId;
+        this.callbackWaitTimeout = callbackWaitTimeout;
         setClientPlayedGame();
         initGCSession();
     }
@@ -49,15 +53,6 @@ public abstract class AbstractDotaClient {
         clientHelloMessage.getBody().setEngine(ESourceEngine.k_ESE_Source2);
         gameCoordinator.send(clientHelloMessage, applicationId, k_EMsgGCClientHello);
         GCSessionCallbackHandler.handle(gcSessionCallback, callbackWaitTimeout).getBody().build();
-    }
-
-    /**
-     * Set time which init callback handlers will wait for packet message from Steam Network server
-     *
-     * @param callbackWaitTimeout of the callback handler
-     */
-    public void setCallbackWaitTimeout(long callbackWaitTimeout) {
-        this.callbackWaitTimeout = callbackWaitTimeout;
     }
 
     public abstract CMsgGCMatchDetailsResponse getMatchDetails(long matchId);

--- a/steam-client/src/main/java/com/avenga/steamclient/steam/dota/AbstractDotaClient.java
+++ b/steam-client/src/main/java/com/avenga/steamclient/steam/dota/AbstractDotaClient.java
@@ -21,16 +21,17 @@ public abstract class AbstractDotaClient {
 
     protected final AbstractGameCoordinator gameCoordinator;
 
+    protected long callbackWaitTimeout = 20000;
     protected int applicationId;
 
-    public AbstractDotaClient(AbstractGameCoordinator gameCoordinator, int applicationId) {
+    public AbstractDotaClient(AbstractGameCoordinator gameCoordinator, int applicationId) throws CallbackTimeoutException {
         this.gameCoordinator = gameCoordinator;
         this.applicationId = applicationId;
         setClientPlayedGame();
         initGCSession();
     }
 
-    protected void setClientPlayedGame() {
+    protected void setClientPlayedGame() throws CallbackTimeoutException {
         var client = gameCoordinator.getClient();
         var gamePlayedCallback = client.addCallbackToQueue(ClientGameConnectTokens.code());
         var gamePlayedMessage = new ClientMessageProtobuf<CMsgClientGamesPlayed.Builder>(CMsgClientGamesPlayed.class, ClientGamesPlayed);
@@ -39,15 +40,24 @@ public abstract class AbstractDotaClient {
                 .build();
         gamePlayedMessage.getBody().addGamesPlayed(gamePlayed);
         client.send(gamePlayedMessage);
-        GamePlayedClientCallbackHandler.handle(gamePlayedCallback);
+        GamePlayedClientCallbackHandler.handle(gamePlayedCallback, callbackWaitTimeout);
     }
 
-    protected void initGCSession() {
+    protected void initGCSession() throws CallbackTimeoutException {
         var gcSessionCallback = gameCoordinator.addCallback(k_EMsgGCClientWelcome.getNumber());
         var clientHelloMessage = new ClientGCProtobufMessage<CMsgClientHello.Builder>(CMsgClientHello.class, k_EMsgGCClientHello.getNumber());
         clientHelloMessage.getBody().setEngine(ESourceEngine.k_ESE_Source2);
         gameCoordinator.send(clientHelloMessage, applicationId, k_EMsgGCClientHello);
-        GCSessionCallbackHandler.handle(gcSessionCallback).getBody().build();
+        GCSessionCallbackHandler.handle(gcSessionCallback, callbackWaitTimeout).getBody().build();
+    }
+
+    /**
+     * Set time which init callback handlers will wait for packet message from Steam Network server
+     *
+     * @param callbackWaitTimeout of the callback handler
+     */
+    public void setCallbackWaitTimeout(long callbackWaitTimeout) {
+        this.callbackWaitTimeout = callbackWaitTimeout;
     }
 
     public abstract CMsgGCMatchDetailsResponse getMatchDetails(long matchId);

--- a/steam-client/src/main/java/com/avenga/steamclient/steam/dota/impl/DotaClient.java
+++ b/steam-client/src/main/java/com/avenga/steamclient/steam/dota/impl/DotaClient.java
@@ -17,13 +17,22 @@ import static com.avenga.steamclient.protobufs.dota.DotaGCMessagesId.EDOTAGCMsg.
 public class DotaClient extends AbstractDotaClient {
 
     private static final int DEFAULT_APPLICATION_ID = 570;
+    private static final long DEFAULT_CALLBACK_WAIT_TIMEOUT = 20000;
 
     public DotaClient(AbstractGameCoordinator gameCoordinator) throws CallbackTimeoutException {
-        super(gameCoordinator, DEFAULT_APPLICATION_ID);
+        super(gameCoordinator, DEFAULT_APPLICATION_ID, DEFAULT_CALLBACK_WAIT_TIMEOUT);
+    }
+
+    public DotaClient(AbstractGameCoordinator gameCoordinator, long callbackWaitTimeout) throws CallbackTimeoutException {
+        super(gameCoordinator, DEFAULT_APPLICATION_ID, callbackWaitTimeout);
     }
 
     public DotaClient(AbstractGameCoordinator gameCoordinator, int applicationId) throws CallbackTimeoutException {
-        super(gameCoordinator, applicationId);
+        super(gameCoordinator, applicationId, DEFAULT_CALLBACK_WAIT_TIMEOUT);
+    }
+
+    public DotaClient(AbstractGameCoordinator gameCoordinator, int applicationId, long callbackWaitTimeout) throws CallbackTimeoutException {
+        super(gameCoordinator, applicationId, callbackWaitTimeout);
     }
 
     /**

--- a/steam-client/src/main/java/com/avenga/steamclient/steam/dota/impl/DotaClient.java
+++ b/steam-client/src/main/java/com/avenga/steamclient/steam/dota/impl/DotaClient.java
@@ -18,11 +18,11 @@ public class DotaClient extends AbstractDotaClient {
 
     private static final int DEFAULT_APPLICATION_ID = 570;
 
-    public DotaClient(AbstractGameCoordinator gameCoordinator) {
+    public DotaClient(AbstractGameCoordinator gameCoordinator) throws CallbackTimeoutException {
         super(gameCoordinator, DEFAULT_APPLICATION_ID);
     }
 
-    public DotaClient(AbstractGameCoordinator gameCoordinator, int applicationId) {
+    public DotaClient(AbstractGameCoordinator gameCoordinator, int applicationId) throws CallbackTimeoutException {
         super(gameCoordinator, applicationId);
     }
 

--- a/steam-language-gen/pom.xml
+++ b/steam-language-gen/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.avenga</groupId>
         <artifactId>parent-steam-client</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>steam-language-gen</artifactId>


### PR DESCRIPTION
**Description:** Sometimes Game Coordinator server or Steam Network server won't respond on the request. To prevent endless waiting of the callback, we need to wait for specific time and cancel callback.