### PR TITLE
Fixed asynchronous core re-open connection logic

### DIFF
--- a/steam-client/src/main/java/com/avenga/steamclient/network/EnvelopeEncryptedConnection.java
+++ b/steam-client/src/main/java/com/avenga/steamclient/network/EnvelopeEncryptedConnection.java
@@ -55,7 +55,7 @@ public class EnvelopeEncryptedConnection extends Connection {
                 return;
             }
 
-            PacketMessage packetMessage = CMClient.getPacketMsg(e.getData());
+            PacketMessage packetMessage = CMClient.getPacketMessage(e.getData());
 
             if (!isExpectedEMsg(packetMessage.getMessageType())) {
                 LOGGER.debug("Rejected EMsg: " + packetMessage.getMessageType() + " during channel setup");

--- a/steam-client/src/main/java/com/avenga/steamclient/steam/CMClient.java
+++ b/steam-client/src/main/java/com/avenga/steamclient/steam/CMClient.java
@@ -319,7 +319,8 @@ public class CMClient {
         onClientDisconnected(disconnectedEventArgs.isUserInitiated() || expectDisconnection);
 
         if (Objects.nonNull(disconnectCallback) && !disconnectCallback.isDone()) {
-            LOGGER.debug("Is disconnect callback completed: {}", disconnectCallback.complete(true));
+            var completeResult = disconnectCallback.complete(true);
+            LOGGER.debug("Is disconnect callback completed: {}", completeResult);
         }
     };
 

--- a/steam-client/src/main/java/com/avenga/steamclient/steam/client/SteamClient.java
+++ b/steam-client/src/main/java/com/avenga/steamclient/steam/client/SteamClient.java
@@ -416,21 +416,12 @@ public class SteamClient extends CMClient {
         connectingInProgress = true;
         while (connectingInProgress) {
             try {
-                this.disconnectAndWait();
                 this.connect(DEFAULT_RECONECT_TIMEOUT);
             } catch (CallbackTimeoutException e) {
                 waitBeforeNextTry();
                 continue;
             }
             connectingInProgress = false;
-        }
-    }
-
-    private void disconnectAndWait() throws CallbackTimeoutException {
-        if (this.isConnected()) {
-            var disconnectCallback = addCallbackToQueue(DisconnectedClientCallbackHandler.CALLBACK_MESSAGE_CODE);
-            this.disconnect();
-            DisconnectedClientCallbackHandler.handle(disconnectCallback, DEFAULT_RECONECT_TIMEOUT, this);
         }
     }
 

--- a/steam-client/src/main/java/com/avenga/steamclient/steam/handler/MultiClientPacketHandler.java
+++ b/steam-client/src/main/java/com/avenga/steamclient/steam/handler/MultiClientPacketHandler.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 
-import static com.avenga.steamclient.steam.CMClient.getPacketMsg;
+import static com.avenga.steamclient.steam.CMClient.getPacketMessage;
 
 public class MultiClientPacketHandler implements ClientPacketHandler {
 
@@ -58,7 +58,7 @@ public class MultiClientPacketHandler implements ClientPacketHandler {
                 int subSize = binaryReader.readInt();
                 byte[] subData = binaryReader.readBytes(subSize);
 
-                PacketMessage subPacketMessage = getPacketMsg(subData);
+                PacketMessage subPacketMessage = getPacketMessage(subData);
                 packetMessages.add(subPacketMessage);
             }
         } catch (IOException e) {


### PR DESCRIPTION
**Description:** Internal `connect` method previously call `disconnect` method before initiating new connection. Due to asynchronous logic of the `disconnect` method new connection event handlers were removed instead of old connection event handlers.