### PR TITLE
Replaced permanent ban logic with temporal ban

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ Depends on platform add the appropriate cryptography dependency to your project:
     <dependency>
         <groupId>com.avenga</groupId>
         <artifactId>steam-client</artifactId>
-        <version>1.0.0</version>
+        <version>1.3.1</version>
     </dependency>
 </dependencies>
 ```
  **Gradle**
 ```groovy
-compile group: 'com.avenga', name: 'steam-client', version: '1.0.0'
+compile group: 'com.avenga', name: 'steam-client', version: '1.3.1'
 ```
 
 ## How to use DOTA2-Aghanim

--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ Depends on platform add the appropriate cryptography dependency to your project:
     <dependency>
         <groupId>com.avenga</groupId>
         <artifactId>steam-client</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.2</version>
     </dependency>
 </dependencies>
 ```
  **Gradle**
 ```groovy
-compile group: 'com.avenga', name: 'steam-client', version: '1.3.1'
+compile group: 'com.avenga', name: 'steam-client', version: '1.3.2'
 ```
 
 ## How to use DOTA2-Aghanim

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.avenga</groupId>
     <artifactId>parent-steam-client</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.avenga</groupId>
     <artifactId>parent-steam-client</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/steam-client/pom.xml
+++ b/steam-client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.avenga</groupId>
         <artifactId>parent-steam-client</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.2</version>
     </parent>
 
     <artifactId>steam-client</artifactId>

--- a/steam-client/pom.xml
+++ b/steam-client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.avenga</groupId>
         <artifactId>parent-steam-client</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </parent>
 
     <artifactId>steam-client</artifactId>
@@ -25,7 +25,7 @@
         <protoc-jar-maven-plugin.version>3.11.1</protoc-jar-maven-plugin.version>
         <slf4j-api.version>1.7.30</slf4j-api.version>
         <bcprov-jdk15on.version>1.64</bcprov-jdk15on.version>
-        <Java-WebSocket.version>1.4.0</Java-WebSocket.version>
+        <Java-WebSocket.version>1.5.1</Java-WebSocket.version>
         <jackson.version>2.10.1</jackson.version>
         <cvurl-io.version>1.3</cvurl-io.version>
     </properties>

--- a/steam-client/src/main/java/com/avenga/steamclient/model/steam/user/LogOnDetailsRecord.java
+++ b/steam-client/src/main/java/com/avenga/steamclient/model/steam/user/LogOnDetailsRecord.java
@@ -13,6 +13,7 @@ public class LogOnDetailsRecord {
     public static final long RECONNECT_TIMEOUT = 5000;
     private static final long LOG_ON_OVER_LIMIT_BLOCKED_TIME = 6;
     private static final int PROXY_MAX_RATE_LIMIT_FAILURES = 5;
+    private static final long UNAVAILABLE_ACCOUNT_BAN_PERIOD = 1;
 
     private LogOnDetails logOnDetails;
     private Instant blockedTime;
@@ -54,6 +55,10 @@ public class LogOnDetailsRecord {
 
     public void blockPermanently() {
         this.permanentlyBlocked = true;
+    }
+
+    public void blockUnavailableAccount() {
+        this.blockedTime = Instant.now().plus(UNAVAILABLE_ACCOUNT_BAN_PERIOD, ChronoUnit.DAYS);
     }
 
     public void resetRateLimitFailures() {

--- a/steam-client/src/main/java/com/avenga/steamclient/provider/UserCredentialsProvider.java
+++ b/steam-client/src/main/java/com/avenga/steamclient/provider/UserCredentialsProvider.java
@@ -49,9 +49,12 @@ public class UserCredentialsProvider {
     }
 
     public void returnKey(LogOnDetailsRecord detailsRecord) {
-        if (detailsRecord.isBlocked() || detailsRecord.isPermanentlyBlocked()) {
+        if (detailsRecord.isBlocked()) {
             LOGGER.debug("{}: User {} was banned until: {}", clientName, detailsRecord.getLogOnDetails().getUsername(),
                     detailsRecord.getBlockedTime());
+            bannedCredentialRecords.add(detailsRecord);
+        } else if (detailsRecord.isPermanentlyBlocked()) {
+            LOGGER.debug("{}: User {} was permanently blocked", clientName, detailsRecord.getLogOnDetails().getUsername());
             bannedCredentialRecords.add(detailsRecord);
         } else {
             detailsRecord.resetRateLimitFailures();

--- a/steam-client/src/main/java/com/avenga/steamclient/steam/asyncclient/SteamClientAsync.java
+++ b/steam-client/src/main/java/com/avenga/steamclient/steam/asyncclient/SteamClientAsync.java
@@ -55,7 +55,7 @@ public class SteamClientAsync extends CMClient {
      * @param configuration The configuration to use for this client.
      */
     public SteamClientAsync(SteamConfiguration configuration) {
-        super(configuration, Constant.DEFAULT_CLIENT_NAME);
+        this(configuration, Constant.DEFAULT_CLIENT_NAME);
     }
 
     /**
@@ -65,7 +65,7 @@ public class SteamClientAsync extends CMClient {
      * @param clientName prefix for logger messages.
      */
     public SteamClientAsync(String clientName) {
-        super(new SteamConfiguration(), clientName);
+        this(new SteamConfiguration(), clientName);
     }
 
     /**

--- a/steam-client/src/main/java/com/avenga/steamclient/steam/client/SteamClient.java
+++ b/steam-client/src/main/java/com/avenga/steamclient/steam/client/SteamClient.java
@@ -728,9 +728,13 @@ public class SteamClient extends CMClient {
     private void checkAndBlockCredentials(EResult logOnResult) {
         switch (logOnResult) {
             case AccountDisabled:
+                currentLoggedUser.get().blockUnavailableAccount();
+                LOGGER.warn("{}: User {} account was disabled.", clientName,
+                        currentLoggedUser.get().getLogOnDetails().getUsername());
+                break;
             case InvalidPassword:
-                currentLoggedUser.get().blockPermanently();
-                LOGGER.warn("{}: User {} has invalid password or account was disabled.", clientName,
+                currentLoggedUser.get().blockUnavailableAccount();
+                LOGGER.warn("{}: User {} has invalid password", clientName,
                         currentLoggedUser.get().getLogOnDetails().getUsername());
                 break;
             case NoConnection:

--- a/steam-language-gen/pom.xml
+++ b/steam-language-gen/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.avenga</groupId>
         <artifactId>parent-steam-client</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </parent>
 
     <artifactId>steam-language-gen</artifactId>

--- a/steam-language-gen/pom.xml
+++ b/steam-language-gen/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.avenga</groupId>
         <artifactId>parent-steam-client</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.2</version>
     </parent>
 
     <artifactId>steam-language-gen</artifactId>


### PR DESCRIPTION
Even for normal working account, Steam can provide `AccountDisabled` login status and we can't set permanent ban in such case. It better to ban such account for long period of the time instead of
the permanent ban.

`InvalidPassword` login status could be fixed without restarting services, so it's better to remove permanent ban for such case as well.